### PR TITLE
gh_actions: add Surge PR preview

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -1,0 +1,45 @@
+name: Surge PR Preview
+
+on:
+  pull_request:
+    # when using teardown: 'true', add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update RIOT data
+        run: make update_riot_data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: ${{ runner.os }}-gems-
+
+      - name: Build
+        uses: jerryjvl/jekyll-build-action@v1
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install surge
+        run: npm --global install surge
+
+      - name: Deploy PR preview
+        run: surge ./_site ${{ github.repository_owner}}-riot-os-org-preview-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Comment URL
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            🚀 PR preview deployed to <https://${{ github.repository_owner}}-riot-os-org-preview-${{ github.event.number }}.surge.sh>


### PR DESCRIPTION
## Contribution description
This PR adds a GH action to allow a preview deployment to [surge.sh](https://surge.sh/).

This needs a token in the organization secrets that currently is generated via my own account, perhaps we could change this in the future.

## Related issues
Was #13
Depends on #17