### PR TITLE
community: fix email links

### DIFF
--- a/community.html
+++ b/community.html
@@ -393,7 +393,7 @@ subtitle: We are an open-source grassroots community gathering companies, academ
           <div class="col-12 col-md-4">
             <h4>Contact</h4>
               <p>
-                Many people are working on RIOT. Public development questions should be directed to the <a href="https://forum.riot-os.org">RIOT forum</a>. If you require one-to-one communication for other development questions, you can contact the <a href="mailto:riot@riot-os.org">RIOT maintainers</a>, and for questions related to formal project establishment or collaboration, you can contact <a href="Emmanuel.Baccelli@inria.fr">Emmanuel Baccelli</a>, <a href="t.schmidt@haw-hamburg.de">Thomas Schmidt</a>, and <a href"m.waehlisch@fu-berlin.de">Matthias W&auml;hlisch</a>.
+                Many people are working on RIOT. Public development questions should be directed to the <a href="https://forum.riot-os.org">RIOT forum</a>. If you require one-to-one communication for other development questions, you can contact the <a href="mailto:riot@riot-os.org">RIOT maintainers</a>, and for questions related to formal project establishment or collaboration, you can contact <a href="mailto:Emmanuel.Baccelli@inria.fr">Emmanuel Baccelli</a>, <a href="mailto:t.schmidt@haw-hamburg.de">Thomas Schmidt</a>, and <a href="mailto:m.waehlisch@fu-berlin.de">Matthias W&auml;hlisch</a>.
               </p>
           </div>
         </div>


### PR DESCRIPTION
## Contribution description
As reported in #14 the links to the emails are broken. This adds the missing `mailto:`.

## Related issues
Fixes #14