### PR TITLE
includes/header: add missing 'scrollto' class

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,7 +31,7 @@
               <!--<li><a href="{% link contributors.html %}">Contributors</a></li>-->
               <li><a href="https://forum.riot-os.org">Forum</a></li>
               <li><a href="https://github.com/topics/riot-os">GitHub</a></li>
-              <li><a href="{% link community.html %}#socialmedia">Social Media</a></li>
+              <li><a class="scrollto" href="{% link community.html %}#socialmedia">Social Media</a></li>
               <li><a href="{% link branding.html %}">Branding</a></li>
               <li><a href="https://github.com/RIOT-OS/RIOT/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a></li>
             </ul>


### PR DESCRIPTION
## Contribution description
This adds the `scrollto` class to the `Social Media` link, so it triggers the correct scrolling function in `main.js`. This prevents from scrolling to the middle of the social images, when clicking from within the community page.