### PR TITLE
index: fix contributors counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ main: true
             <p>Commits</p>
           </div>
           <div class="col-md-3 col-12 text-center">
-            <h2 class="count"> {{ site.data.riot_stats.contributors }} </h2>
+            <h2 class="count"> {{ site.data.contributors.size }} </h2>
             <p>Contributors</p>
           </div>
           <div class="col-md-3 col-12 text-center">


### PR DESCRIPTION
## Contribution description
With #17 RIOT stats do not contain the amount of contributors, it can be just retrieved from the contributors file. This fixes the counter.