### PR TITLE
jekyll: change baseurl to "/"

### DIFF
--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,1 +1,1 @@
-baseurl: "/riot-os.org"
+baseurl: "/"


### PR DESCRIPTION
this will fix problems with the new site url relaunch.riot-os.org.