### PR TITLE
add missing JEKYLL_ENV to production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ endif
 PRODUCTION ?= 0
 ifeq ($(PRODUCTION),1)
   JEKYLL_BUILD_ARGS += --config _config.yml,_config_production.yml
+  export JEKYLL_ENV=production
 endif
 
 $(RIOTBASE):

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,1 +1,1 @@
-baseurl: "/"
+baseurl: ""


### PR DESCRIPTION
## Contribution Description

This PR adds a missing JEKYLL_ENV variable when running in production. 
This is required to in order to build properly when using PRODUCTION=1.