### PR TITLE
deployment: add CNAME to allow for custom domain name

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+relaunch.riot-os.org


### PR DESCRIPTION
this file is required to enable custom domain names.

note that when configuring a custom domain name using the web frontend, a CNAME file will be automatically created in the `gh-pages` branch. this file will be removed with every automatic deployment based on our GitHub Actions if the CNAME file is not available in master.