### PR TITLE
remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-relaunch.riot-os.org


### PR DESCRIPTION
This PR removes the CNAME file, used by the old Github Pages setup.
Since we are redirecting the traffic internally, we need to get rid of this resolution (otherwise `riot-os.github.io` redirects internally to relaunch.riot-os.org, which already points to the server...)