### PR TITLE
includes/use_cases_carousel: limit quote lines

### DIFF
--- a/_includes/use-cases-carousel.html
+++ b/_includes/use-cases-carousel.html
@@ -16,10 +16,12 @@
                 {% for use_case in site.use_cases %}
                   {% if use_case.quote %}
                     <div class="swiper-slide">
-                      <div class="use-case-item rounded">
+                      <div class="use-case-item rounded h-100 d-flex flex-column">
                         <p>
                             <i class="bx bxs-quote-alt-left quote-icon-left"></i>
-                            {{ use_case.quote }}
+                            <span class="quote">
+                              {{ use_case.quote }}
+                            </span>
                             <i class="bx bxs-quote-alt-right quote-icon-right"></i>
                         </p>
                         <img src="{{ use_case.user_photo | default: 'riot-logo.png' | prepend: 'assets/img/use-cases/' | relative_url }}"
@@ -27,8 +29,8 @@
                         <h3>{{ use_case.user }}</h3>
                         <h4>{{ use_case.user_position }}, {{ use_case.company }}</h4>
                         {% if use_case.project %}
-                        <div class="col-lg-12 mt-4 text-center">
-                          <a href="{{ use_case.url }}" class="btn-learn-more btn-lg", role="button">Learn more!</a>
+                        <div class="col-12 mb-3 m-auto">
+                          <a href="{{ use_case.url }}" class="btn-learn-more btn-lg m-auto", role="button">Learn more!</a>
                         </div>
                         {% endif %}
                       </div>

--- a/_layouts/use-case.html
+++ b/_layouts/use-case.html
@@ -14,7 +14,7 @@ layout: base
           <div class="row pt-4 text-center">
             <div class="col-12">
               {% if page.company_logo %}
-              <img src="{{ page.company_logo | default: 'riot-logo.png' | prepend: 'assets/img/use-cases/' | relative_url }}" class="rounded-3 img-fluid" alt="{{ page.company }} logo">
+              <img src="{{ page.company_logo | default: 'riot-logo.png' | prepend: 'assets/img/use-cases/' | relative_url }}" class="img-fluid" alt="{{ page.company }} logo">
               {% endif %}
               <h4 class="text-uppercase d-inline-block ps-3"><a href="{{ page.company_url | default: '#'}}">{{ page.company }}</a></h4>
             </div>

--- a/_sass/components/use-cases-carousel.scss
+++ b/_sass/components/use-cases-carousel.scss
@@ -4,8 +4,9 @@
 #use-cases-carousel {
     .use-case-item {
       box-sizing: content-box;
-      padding: 30px 30px 0 30px;
-      margin: 30px 15px;
+      padding: 20px 20px 0 20px;
+      margin-left: 15px;
+      margin-right: 15px;
       text-align: center;
       min-height: 350px;
       box-shadow: 0 .5rem 1rem rgba(0,0,0,.15)!important;
@@ -29,25 +30,39 @@
       .quote-icon-left, .quote-icon-right {
         color: $primary-light;
         font-size: 26px;
+        width: 100%;
       }
       .quote-icon-left {
         display: inline-block;
         left: -5px;
         position: relative;
+        text-align-last: left;
+        width: 100%;
       }
       .quote-icon-right {
         display: inline-block;
         right: -5px;
         position: relative;
+        text-align: right;
         top: 10px;
       }
       p {
         font-style: italic;
         margin: 0 auto 15px auto;
+        .quote {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-line-clamp: 3; /* number of lines to show */
+          -webkit-box-orient: vertical;
+        }
       }
     }
+    .swiper-slide {
+      height: auto;
+    }
     .swiper-pagination {
-      margin-top: 20px;
+      margin-top: 60px;
       position: relative;
       .swiper-pagination-bullet {
         width: 12px;


### PR DESCRIPTION
## Contribution description
This PR removes the rounding of logos in the use-cases pages, and makes the carousel of equal height by limiting the number of lines in the quotes, as described in #52.

For testing I suggest rebasing on top of #51, which introduces a quote that is smaller than the current ones.

Fixes #52.