### PR TITLE
[PoC] includes/logo-wall: add shadow to logos

### DIFF
--- a/_includes/use-cases-logo-wall.html
+++ b/_includes/use-cases-logo-wall.html
@@ -1,12 +1,14 @@
-        <div class="row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-3 row-cols-3 d-flex justify-content-center">
+        <div class="row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-3 row-cols-3 d-flex justify-content-center" id="use-cases-logo-wall">
           {% for use_cases in site.use_cases %}
             {% if use_cases.company %}
-            <div class="col">
-              <div class="card border-0 d-flex h-100 p-4">
-                <div class="card d-flex align-items-center justify-content-center h-100 border-0">
-                  <a href="{{ use_cases.company_url }}" target="_blank"><img class="card-img-top" src="{{ use_cases.company_logo | prepend: 'assets/img/use-cases/' | relative_url }}" alt="{{ use_cases.company }}"></a>
+            <div class="col mt-4">
+              <a href="{{ use_cases.company_url }}" target="_blank">
+                <div class="card border-0 d-flex h-100 p-4 rounded">
+                  <div class="d-flex align-items-center justify-content-center h-100 border-0">
+                    <img class="card-img-top" src="{{ use_cases.company_logo | prepend: 'assets/img/use-cases/' | relative_url }}" alt="{{ use_cases.company }}">
+                  </div>
                 </div>
-              </div>
+              </a>
             </div>
             {% endif %}
           {% endfor %}

--- a/_sass/components/use-cases-logo-wall.scss
+++ b/_sass/components/use-cases-logo-wall.scss
@@ -1,0 +1,9 @@
+#use-cases-logo-wall {
+    .card {
+        box-shadow: 0 .125rem .2rem rgba(0,0,0,.075);
+        transition: all 0.3s;
+        &:hover {
+            box-shadow: 0 .3rem .5rem rgba(0,0,0,.15)!important;
+        }
+    }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -17,3 +17,4 @@ $baseurl: "{{ site.baseurl }}";
 @import "components/navbar";
 @import "components/simple-page-header";
 @import "components/use-cases-carousel";
+@import "components/use-cases-logo-wall";


### PR DESCRIPTION
## Contribution description
This adds subtle shadows to the logos in the logo wall, as an attempt to stress that each one is given an equal portion of the space.

Related to #52 