### PR TITLE
fix: Update link to HiL nightlies

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@ main: true
                         The RIOT community cares about code quality. Therefore, we use established tools such as
                         <a href="http://embunit.sourceforge.net/embunit/">embUnit - Unit Testing </a>
                         and <a href="https://ci.riot-os.org/"> Continuous Integration</a>, performing
-                        <a href="https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/robot/robot.xml">Hardware in the Loop (HIL)</a>
+                        <a href="https://hil.riot-os.org/results/">Hardware in the Loop (HIL)</a>
                         testing on multiple boards nightly.
                       </p>
                     </div>


### PR DESCRIPTION
Now that the new HiL nightlies website is up, we should link to it.