### PR TITLE
gh/workflows/deployment: adapt to rsync

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Setup Environment.
+        run: |
+          gem install jekyll bundler
+          bundle install
+
       - name: Update RIOT data
         run: make update_riot_data
         env:
@@ -28,9 +38,15 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: ${{ runner.os }}-gems-
 
+      - name: Build Site with Jekyll.
+        run: PRODUCTION=1 make build
+
       - name: Deploy
-        uses: helaili/jekyll-action@v2
+        uses: burnett01/rsync-deployments@4.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          target_branch: 'gh-pages'
-          jekyll_build_options: '--config _config.yml,_config_production.yml'
+          switches: -avzr --delete
+          path: _site/
+          remote_path: /
+          remote_host: ${{ secrets.SSH_REMOTE_HOST }}
+          remote_user: ${{ secrets.SSH_REMOTE_USER }}
+          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Contribution Description

This PR adapts the deployment workflow to deploy the website directly to an internal server (HAW).
Since we already had an IPv6 proxy running there (and the fact Github Pages complained regarding asymmetric SSH keys for IPv4 and IPv6), we opted to skip the proxy and simply serve the website from there.

The output of this PR can be seen in https://github.com/jia200x/riot-os.org/actions/runs/710035465. As expected, the files were deployed in the server:
```
-bash$ ls
2021    boards.html    community.html     cpus.html     faqs          index.html       portfolio-details.html
assets  branding.html  contributors.html  drivers.html  imprint.html  inner-page.html  use_cases
```

The GH Secrets were already added to the repository, so we should se the effects right after merge
