### PR TITLE
index: fix link to Embedded Unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ main: true
                       <h6 class="mb-2 text-muted">RIOT is constantly tested.</h6>
                       <p>
                         The RIOT community cares about code quality. Therefore, we use established tools such as
-                        <a href="http://embunit.sourceforge.net/embunit/"  target="_blank">embUnit - Unit Testing </a>
+                        <a href="https://sourceforge.net/projects/embunit/"  target="_blank">embUnit - Unit Testing </a>
                         and <a href="https://ci.riot-os.org/" target="_blank"> Continuous Integration</a>, performing
                         <a href="https://hil.riot-os.org/results/" target="_blank">Hardware in the Loop (HIL)</a>
                         testing on multiple boards nightly.


### PR DESCRIPTION
This fixes the broken link to Embedded Unit on the index page. Thanks https://twitter.com/goshik/status/1378965521618571266