### PR TITLE
Add a link to the documentation in the Header bar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,6 +19,7 @@
               <li><a href="{% link index.html %}#get-started">Get started</a></li>
               <li><a href="{% link index.html %}#use-cases">Use Cases</a></li>
               <li><a href="{% link index.html %}#faq">FAQ</a></li>
+              <li><a href="https://doc.riot-os.org/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right align-text-bottom"></i></a></li>
             </ul>
           </li>
           <li class="dropdown">


### PR DESCRIPTION
I often find myself on the RIOT-OS Homepage, when in reality I wanted to go to the docs. While there is a link somewhere on the homepage i takes some time to get there.
this adds a link into the users navigation.