### PR TITLE
community: fix RIOT Summit 2021 alt text

### DIFF
--- a/community.html
+++ b/community.html
@@ -227,7 +227,7 @@ subtitle: We are an open-source grassroots community gathering companies, academ
                 <h2 class="mb-0">RIOT Summit 2021</h2>
                 <h3>Online, the Internet</h3>
                 <a href="https://summit.riot-os.org/2021" class="overflow-hidden" target="_blank">
-                  <img src="{{ "assets/img/summits/summit2021.jpg" | relative_url }}" class="card-img" alt="Photo RIOT Summit 2020">
+                  <img src="{{ "assets/img/summits/summit2021.jpg" | relative_url }}" class="card-img" alt="Photo RIOT Summit 2021">
                   <div class="card-img-overlay">
                     <p class="card-text">Keynote speaker: Henning Schulzrinne (Columbia University)</p>
                   </div>


### PR DESCRIPTION
Just a small nitpick from #89: the alternative text for the image should say 2021 instead of 2020.