### PR TITLE
README: add deployment workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deployment status][deployment-badge]][deployment-link]
+
 ## Source code for riot-os.org
 
 ### Building
@@ -87,3 +89,6 @@ The metadata required for an use case is the following:
 ### Blog
 For now the blog is not published. For local development you can render the blog
 section by setting `blog` to `true` in `_config.yml`.
+
+[deployment-badge]: https://github.com/RIOT-OS/riot-os.org/actions/workflows/deployment.yml/badge.svg
+[deployment-link]: https://github.com/RIOT-OS/riot-os.org/actions/workflows/deployment.yml


### PR DESCRIPTION
This adds the Github badge for the deployment workflow to the `README.md`, allowing to see the status at a glance.

Edit: To see how it looks check the rich diff of the file https://github.com/RIOT-OS/riot-os.org/pull/94/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5