### PR TITLE
socialmedia/community: use custom URL for YouTube channel

### DIFF
--- a/_includes/social-media.html
+++ b/_includes/social-media.html
@@ -1,6 +1,6 @@
                   <a href="https://github.com/RIOT-OS/RIOT" target="_blank"><span class="visually-hidden">Go to RIOT OS Github</span><i class="ri-github-fill"></i></a>
                   <a href="https://twitter.com/RIOT_OS" target="_blank"><span class="visually-hidden">Go to RIOT OS Twitter</span><i class="ri-twitter-fill"></i></a>
                   <a href="https://fosstodon.org/@RIOT_OS" target="_blank" rel="me"><span class="visually-hidden">Go to RIOT OS Mastodon</span><i class="ri-mastodon-fill"></i></a>
-                  <a href="https://www.youtube.com/channel/UCmcXy2qyoQfq7ByoxtFSOjg" target="_blank"><span class="visually-hidden">Go to RIOT OS Youtube channel</span><i class="ri-youtube-fill"></i></a>
+                  <a href="https://www.youtube.com/c/RIOT-IoT" target="_blank"><span class="visually-hidden">Go to RIOT OS Youtube channel</span><i class="ri-youtube-fill"></i></a>
                   <a href="https://forum.riot-os.org" target="_blank"><span class="visually-hidden">Go to RIOT OS forum</span><i class="ri-chat-1-fill"></i></a>
 

--- a/community.html
+++ b/community.html
@@ -116,11 +116,11 @@ subtitle: We are an open-source grassroots community gathering companies, academ
          <div class="col-12 col-md-4 mt-5">
            <div class="card border-0 d-flex h-100">
              <div class="card-header d-flex align-items-center justify-content-center h-100 border-0">
-               <a href="https://www.youtube.com/channel/UCmcXy2qyoQfq7ByoxtFSOjg" target="_blank"><img class="card-img-top" src="{{ "assets/img/yt_logo_rgb_light.png" | relative_url }}" alt="Youtube logo"></a>
+               <a href="https://www.youtube.com/c/RIOT-IoT" target="_blank"><img class="card-img-top" src="{{ "assets/img/yt_logo_rgb_light.png" | relative_url }}" alt="Youtube logo"></a>
              </div>
              <div class="card-body px-0">
                <!--<h4 class="card-title">Our forum for discussions.</h4>-->
-               <a href="https://www.youtube.com/channel/UCmcXy2qyoQfq7ByoxtFSOjg" class="btn btn-outline-primary w-100" target="_blank">Watch RIOT</a>
+               <a href="https://www.youtube.com/c/RIOT-IoT" class="btn btn-outline-primary w-100" target="_blank">Watch RIOT</a>
              </div>
            </div>
          </div>


### PR DESCRIPTION
We have a [custom URL](https://support.google.com/youtube/answer/2657968?hl=en) for our YouTube channel, so let's use it for better brand recognition and so it can be easier remembered.