### PR TITLE
Gemfile: add webrick dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "jekyll"
 gem "rouge"
+gem "webrick"


### PR DESCRIPTION
There seems to be an issue when serving jekyll on Ruby 3.0. The problem and solution are explained in https://github.com/jekyll/jekyll/issues/8523. This adds `webrick` gem as a dependency. Not sure how this affects other versions, but at least I need it locally to actually be able to bring the server up.

Let's see what the CI says, also maybe some other maintainer can check with their setup?