### PR TITLE
github/workflows: add keepalive dummy commit step

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,3 +50,11 @@ jobs:
           remote_host: ${{ secrets.SSH_REMOTE_HOST }}
           remote_user: ${{ secrets.SSH_REMOTE_USER }}
           remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Keep-alive commit
+        uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          commit_message: Nothing to see here
+          committer_username: riot-ci
+          committer_email: maintainer@riot-os.org
+          time_elapsed: 1 # TODO: go back to 50 days default


### PR DESCRIPTION
Github disables workflows from repos that have no activity in the last 60 days. This causes our deployment workflow to be disabled. To avoid hitting this limit, we can use the [Keepalive Workflow](https://github.com/marketplace/actions/keepalive-workflow) action to add a commit every 50 days. This PR adds the action as a step of `deployment`, which runs everyday.