### PR TITLE
github/workflows: add token for keepalive

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -58,3 +58,4 @@ jobs:
           committer_username: riot-ci
           committer_email: maintainer@riot-os.org
           time_elapsed: 1 # TODO: go back to 50 days default
+          gh_token: ${{ secrets.RIOT_CI_TOKEN }}


### PR DESCRIPTION
As discussed in #103, the keepalive workflow step is failing due to permissions to push to `master`. Instead of removing all protections for `master`, we now allow admins to push, and added @riot-ci to the group. We then created an access token for @riot-ci, added it to the repo's secrets and now it's being used.

We're not 100% this is the final solution, more settings may need tweaking...

@miri64 