### PR TITLE
github/deployment: update ruby action

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
+          bundler-cache: true
 
       - name: Setup Environment.
         run: |


### PR DESCRIPTION
The ruby setup action that we use is deprecated. Update to the replacement: https://github.com/ruby/setup-ruby