### PR TITLE
Gemfile.lock: update to latest deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   x86_64-linux
@@ -63,6 +64,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   rouge
+  webrick
 
 BUNDLED WITH
    2.2.9


### PR DESCRIPTION
#98 added a new dependency to Gemfile, this updates the .lock, because the GH seems to complain about it.