### PR TITLE
github/deployment: Fix Jekyll version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Setup Environment.
         run: |
-          gem install jekyll bundler
+          gem install jekyll -v 4.2.2
+          gem install bundler
           bundle install
 
       - name: Update RIOT data


### PR DESCRIPTION
This fixes the Jekyll to a version using a sass-embedded version compatible with the RubyGems in the docker container.

Tested locally using [`act`](https://github.com/nektos/act)