### PR TITLE
github/workflows: remove keepalive

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,12 +53,3 @@ jobs:
           remote_port: ${{ secrets.SSH_REMOTE_PORT }}
           remote_user: ${{ secrets.SSH_REMOTE_USER }}
           remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Keep-alive commit
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-          commit_message: Nothing to see here
-          committer_username: riot-ci
-          committer_email: maintainer@riot-os.org
-          time_elapsed: 1 # TODO: go back to 50 days default
-          gh_token: ${{ secrets.RIOT_CI_TOKEN }}


### PR DESCRIPTION
This didn't work and shows deployment action as failing. Let's remove it...

See #103 