### PR TITLE
index: microkernel -> small kernel

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ main: true
               <div class="card-body">
                 <div class="card-text">
                   <p class="fw-bold text-center">
-                    Benefit from a microkernel and tickless scheduling on the lower end.
+                    Benefit from a small kernel and tickless scheduling on the lower end.
                   </p>
                   <ul class="check_style">
                     <li class="pb-3"> Robust runtime system </li>


### PR DESCRIPTION
Don't call RIOT a microkernel, that just sets the wrong expectations.
We only have threads, but no separation between them or any notion of kernel/userspace.
By that notion Linux would also be a microkernel.