### PR TITLE
Actions/deployment: specify bundler version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Environment.
         run: |
           gem install jekyll -v 4.2.2
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install
 
       - name: Update RIOT data


### PR DESCRIPTION
For some time the deployment action [seems to be failing](https://github.com/RIOT-OS/riot-os.org/actions/runs/7381644762/job/20080409643). The error:
```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```
This tries applying the suggested solution of setting the bundler version to 2.4.22. Not sure we can test if this fixes the issue without merging...