### PR TITLE
footer: Add link to riot-os.org GitHub repo

### DIFF
--- a/_faqs/faq-13.md
+++ b/_faqs/faq-13.md
@@ -1,0 +1,6 @@
+---
+question: I want to contribute to this website. How do I do that?
+---
+
+This website is hosted using Jekyll, so you can add your contributions to the
+<a href="https://github.com/RIOT-OS/riot-os.org">GitHub repository for the website</a>.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,9 @@
         </div>
       </div>
       <div class="copyright">
-        <small>&copy; 2013 - {{ "now" | date: "%Y" }}. All Rights Reserved | <a href="{%link imprint.html %}">Imprint</a></small>
+        <small>&copy; 2013 - {{ "now" | date: "%Y" }}. All Rights Reserved |
+        <a href="https://github.com/RIOT-OS/riot-os.org" target="_blank">Website Source</a> |
+        <a href="{%link imprint.html %}">Imprint</a></small>
       </div>
     </div>
   </footer><!-- End Footer -->


### PR DESCRIPTION
Fixes https://github.com/RIOT-OS/riot-os.org/issues/79 and follows the suggestion by @sirocyl.