### PR TITLE
Make FAQs linkable

### DIFF
--- a/_faqs/faq-02.md
+++ b/_faqs/faq-02.md
@@ -13,4 +13,6 @@ Last but not least, we think that (L)GPL is a better base than BSD/MIT to keep t
 
 For the record: we have also considered MIT/BSD (see [this thread](https://lists.riot-os.org/pipermail/devel/2014-December/001468.html)), but there was not enthusiastic majority supporting such a switch.
 
-Compare https://github.com/RIOT-OS/RIOT/issues/2128
+Compare [https://github.com/RIOT-OS/RIOT/issues/2128][GH2128]
+
+[GH2128]: https://github.com/RIOT-OS/RIOT/issues/2128

--- a/_faqs/faq-02.md
+++ b/_faqs/faq-02.md
@@ -1,5 +1,6 @@
 ---
 question: Why LGPL?
+anchor: faq-why-lgpl
 ---
 
 Studies such as [this one](http://www.gartner.com/newsroom/id/2869521) show that small companies and start-ups are going to determine IoT. More than bigger companies, such small structures need to spread development and maintenance costs for the kernel and all the software that is not their core business. Our analysis is that this is more compatible with LGPL than with BSD/MIT.

--- a/_faqs/faq-12.md
+++ b/_faqs/faq-12.md
@@ -27,7 +27,7 @@ Members in the community mostly belong to one (or more) of the following groups:
 
 RIOT is distributed under a copyleft license and strongly prefers free and open source components over proprietary code and binary blobs.
 Still, RIOT does contain proprietary drivers (some even using binary blobs) where no free alternative is available, e.g. for the ESP WiFi chipset.
-<!-- FIXME: Make FAQ entries linkable and link to "Why LGPL?" -->
+See also [“Why LGPL?”](#faq-why-lgpl)
 
 ##### Vendor Specific SDKs
 

--- a/index.html
+++ b/index.html
@@ -466,9 +466,9 @@ main: true
         <ul class="faq-list">
 
           {% for faqs in site.faqs %}
-            <li>
-              <div data-bs-toggle="collapse" class="collapsed question" href="#faq{{ forloop.index }}">{{ faqs.question }}<i class="bi bi-chevron-down icon-show"></i><i class="bi bi-chevron-up icon-close"></i></div>
-              <div id="faq{{ forloop.index }}" class="collapse" data-bs-parent=".faq-list">
+            <li id="{% if faqs.anchor %}{{ faqs.anchor }}{% else %}faq-{{ forloop.index }}{% endif %}">
+              <div data-bs-toggle="collapse" class="collapsed question" href="#faq-answer-{{ forloop.index }}">{{ faqs.question }}<i class="bi bi-chevron-down icon-show"></i><i class="bi bi-chevron-up icon-close"></i></div>
+              <div id="faq-answer-{{ forloop.index }}" class="collapse" data-bs-parent=".faq-list">
                 <p>
                   {{ faqs.content }}
                 </p>


### PR DESCRIPTION
This makes FAQs linkable, as discussed in https://github.com/RIOT-OS/riot-os.org/pull/125/commits/ef6c8e309bebd793edb00724f457956bb73bb366#r1574781620 (and also piggy-backs a small fixup to make an absolute URL a clickable link).