### PR TITLE
sass/general: fix top margin for FAQ subsections

### DIFF
--- a/_sass/_general.scss
+++ b/_sass/_general.scss
@@ -93,7 +93,3 @@ h1, h2, h3, h4, h5, h6 {
 .text-gray {
   color: $gray !important;
 }
-
-.faq-list h5 {
-   margin-top: 1rem;
-}

--- a/_sass/_general.scss
+++ b/_sass/_general.scss
@@ -93,3 +93,7 @@ h1, h2, h3, h4, h5, h6 {
 .text-gray {
   color: $gray !important;
 }
+
+.faq-list h5 {
+   margin-top: 1rem;
+}

--- a/_sass/pages/index.scss
+++ b/_sass/pages/index.scss
@@ -506,6 +506,7 @@ section {
 
 .faq .faq-list h5 {
    margin-top: 1rem;
+   padding: 0 0 0 25px;
 }
 
 .faq .faq-list p {

--- a/_sass/pages/index.scss
+++ b/_sass/pages/index.scss
@@ -504,6 +504,10 @@ section {
   top: -2px;
 }
 
+.faq .faq-list h5 {
+   margin-top: 1rem;
+}
+
 .faq .faq-list p {
   margin-bottom: 0;
   padding: 10px 0 0 25px;


### PR DESCRIPTION
One more from my side. I noticed that the formatting of the subsections in faq-12 is a bit off in the output. This fixes the top margin for the headings.