### PR TITLE
sass/index: move FAQ entry anchors below sticky header

### DIFF
--- a/_sass/pages/index.scss
+++ b/_sass/pages/index.scss
@@ -655,8 +655,7 @@ section {
     overflow: hidden;
     position: relative;
     background: linear-gradient(0deg, $dark 0%, darken($dark, 10) 100%);
-    padding: 0;
-    padding-top: 90px;
+    padding: 90px 0 0 0;
 
     .carousel-container {
         display: flex;

--- a/_sass/pages/index.scss
+++ b/_sass/pages/index.scss
@@ -656,6 +656,7 @@ section {
     position: relative;
     background: linear-gradient(0deg, $dark 0%, darken($dark, 10) 100%);
     padding: 0;
+    padding-top: 90px;
 
     .carousel-container {
         display: flex;
@@ -819,6 +820,10 @@ section {
       transform: translate(85px, 0%);
     }
   }
+}
+
+:root {
+  scroll-padding-top: 90px;
 }
 
 ///


### PR DESCRIPTION
As a follow-up of https://github.com/RIOT-OS/riot-os.org/pull/127#issuecomment-2070474342, this moves the anchors of FAQ entries below the sticky website header. It just adds 9 lines of CSS, so probably worth the effort @miri64 ?

Tested both on mobile and desktop screen (the sticky header size doesn't change).

Can be tested by opening https://riot-os-riot-os-org-preview-129.surge.sh/#faq-1

