### PR TITLE
community: re-instate #socialmedia

### DIFF
--- a/community.html
+++ b/community.html
@@ -89,7 +89,7 @@ subtitle: We are an open-source grassroots community gathering companies, academ
            </div>
          </div>
 
-         <div class="col-12 col-md-4 mt-5">
+         <div id="socialmedia" class="col-12 col-md-4 mt-5">
            <div class="card border-0 d-flex h-100">
              <div class="card-header d-flex align-items-center justify-content-center h-100 border-0">
                <a href="https://fosstodon.org/@RIOT_OS" target="_blank"><img class="card-img-top" src="{{ "assets/img/mastodon-logo-riot.png" | relative_url }}" alt="Mastodon logo"></a>


### PR DESCRIPTION
In #121 I accidentally removed the `#socialmedia` anchor with the twitter card. This re-adds it to the mastodon card.