### PR TITLE
index.html: fix broken mailing list links

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,9 +393,8 @@ main: true
             </p>
             <p>
               The <a href="https://github.com/RIOT-OS/RIOT/issues?state=open" target="_blank">RIOT issue tracker</a> informs about bugs and enhancement requests. You could also
-              subscribe to the <a href="http://lists.riot-os.org/mailman/listinfo/notifications/" target="_blank">notifications mailing list</a> to get informed about new issues,
-              comments, and pull requests. All commits to the source code will be posted to the
-              <a href="http://lists.riot-os.org/mailman/listinfo/commits" target="_blank">commits mailing list</a>. Take a look at our <a href="https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md" target="_blank">coding conventions</a>.
+              subscribe to the <a href="https://lists.stillroot.org/postorius/lists/notifications.lists.riot-os.org/" target="_blank">notifications mailing list</a> to get informed about new issues,
+              comments, and pull requests. Take a look at our <a href="https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md" target="_blank">coding conventions</a>.
             </p>
           </div>
           <div class="col-12 col-md-6 col-lg-4">


### PR DESCRIPTION
As @jkarinkl pointed out in #138: There are two broken links wrt the mailing lists.

This PR fixes one link and removes the other one as the mailing list has been deleted a while ago.