### PR TITLE
Update imprint

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -6,18 +6,26 @@ subtitle: The friendly Operating System for the Internet of Things
 
 <section class="container">
   <div class="row">
+    <div class="col col-12">
+      <h2>Imprint</h2>
+    </div>
+  </div>
+  <div class="row">
     <div class="col col-12 col-md-4">
-      <h2>Legal notice</h2>
-      <dd>Freie Universit&auml;t Berlin, Institut f&uuml;r Informatik</dd>
-      <dd>Matthias W&auml;hlisch</dd>
-      <dd>Takustr. 9, 14195 Berlin, Germany</dd>
+      <h3>Postal Address</h3>
+      <dd>Prof. Dr. Matthias W&auml;hlisch</dd>
+      <dd>TU Dresden</dd>
+      <dd>Faculty of Computer Science</dd>
+      <dd>Institute of Systems Architecture</dd>
+      <dd>Chair of Distributed and Networked Systems</dd>
+      <dd>Helmholtzstr. 10</dd>
+      <dd>01069 Dresden</dd>
       </p>
     </div>
     <hr class="d-block d-md-none">
     <div class="col col-12 col-md-4">
-      <h2>Contact</h2>
-      <dd>Phone: +49-30-838-50072</dd>
-      <dd>Telefax: +49-30-838-450072</dd>
+      <h3>Other Contacts</h3>
+      <dd>Phone: +49 351 463-382631</dd>
       <dd>E-Mail: riot@riot-os.org</dd>
     </div>
   </div>


### PR DESCRIPTION
During the preparations for the RIOT summit I noticed that the imprint still shows Matthias' old address. I copied the address and phone number from https://summit.riot-os.org/2025/imprint/