### PR TITLE
Replace link to doxygen with link to guides and fix link to deprecated doxygen pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,8 @@
               <li><a href="{% link index.html %}#use-cases">Use Cases</a></li>
               <li><a href="https://www.hackster.io/riot-os" target="_blank">Tutorials@Hackster.io<i class="bi bi-box-arrow-up-right align-text-bottom"></i></a></li>
               <li><a href="{% link index.html %}#faq">FAQ</a></li>
-              <li><a href="https://doc.riot-os.org/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right align-text-bottom"></i></a></li>
+              <li><a href="https://guide.riot-os.org/" target="_blank">Guides <i class="bi bi-box-arrow-up-right align-text-bottom"></i></a></li>
+              <li><a href="https://doc.riot-os.org/" target="_blank">API Documentation <i class="bi bi-box-arrow-up-right align-text-bottom"></i></a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/community.html
+++ b/community.html
@@ -351,7 +351,7 @@ subtitle: We are an open-source grassroots community gathering companies, academ
               <div class="card-body">
                 <h4>Future</h4>
                 <p>
-                  We have a <a href="https://doc.riot-os.org/vision.html">vision</a>.
+                  We have a <a href="https://guide.riot-os.org/general/vision">vision</a>.
                   Be part of the community and follow ongoing enhancements in our
                   <a href="https://github.com/RIOT-OS/RIOT/labels/Type%3A%20new%20feature">issue tracker</a>.
                   Start working on new features or let the RIOT community know what you miss!
@@ -400,7 +400,7 @@ subtitle: We are an open-source grassroots community gathering companies, academ
           <div class="col-12 col-md-4">
             <h4 class="text-white">Future</h4>
               <p>
-                We have a <a href="https://doc.riot-os.org/vision.html" target="_blank">vision</a>. Be part of the community and follow ongoing enhancements in our <a href="https://github.com/RIOT-OS/RIOT/labels/Type%3A%20new%20feature" target="_blank">issue tracker</a>. Start working on new features or let the RIOT community know what you miss!
+                We have a <a href="https://guide.riot-os.org/general/vision" target="_blank">vision</a>. Be part of the community and follow ongoing enhancements in our <a href="https://github.com/RIOT-OS/RIOT/labels/Type%3A%20new%20feature" target="_blank">issue tracker</a>. Start working on new features or let the RIOT community know what you miss!
               </p>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ main: true
                     Program as you are used to. Save time with common environments.
                   </p>
                   <ul class="check_style">
-                    <li class="pb-3"> Standard programming in C, C++, or <a href="https://doc.riot-os.org/using-rust.html" target="_blank">Rust</a></li>
+                    <li class="pb-3"> Standard programming in C, C++, or <a href="https://guide.riot-os.org/rust_tutorials/rust_in_riot" target="_blank">Rust</a></li>
                     <li class="pb-3"> Standard tools: gcc, gdb, valgrind </li>
                     <li class="pb-3"> Zero learning curve for embedded programming </li>
                     <li class="pb-3"> Code mostly without hardware dependence </li>
@@ -268,11 +268,11 @@ main: true
             </a>
           </div>
           <div class="col text-center py-4">
-            <a href="https://doc.riot-os.org/" target="_blank">
+            <a href="https://guide.riot-os.org/" target="_blank">
               <div class="card border-0">
                 <div class="card-body">
                   <i class="ri-file-text-line me-2 fs-2"></i>
-                  <h4 class="pt-3">Read the documentation</h4>
+                  <h4 class="pt-3">Read our guides</h4>
                 </div>
               </div>
             </a>


### PR DESCRIPTION
All of the user documentation now lives under https://guide.riot-os.org.
Progress was tracked under:
- https://github.com/RIOT-OS/RIOT/issues/21575

So I changed the link to the documentation to the guides site, which contains the most useful documentation for beginners.
The API-Documentation (doxygen) is linked there very prominently as well, so it is still easy to discover.

Furthermore some links pointed to outdated user documentation that just shows an empty deprecated page. I updated these to the guide documentation counterparts as well.