### PR TITLE
security.txt: indicate that no bug bounty program is available

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -3,3 +3,4 @@ Expires: 2028-01-13T10:09:55.000Z
 Policy: https://guide.riot-os.org/general/security/
 Preferred-Languages: en
 Encryption: https://riot-os.org/assets/keys/security.asc
+Bug-Bounty: None


### PR DESCRIPTION
Let's be very up front that reports won't get a monetary reward, but only the good feeling to have done the right thing.

This might also reduce the chance of AI slop reports; at least the curl project has drawn the conclusion that not offering a bug bounty program can improve the quality of the bug reports.