### PR TITLE
cpu&boards: add deprecation warnings

### DIFF
--- a/boards.html
+++ b/boards.html
@@ -4,6 +4,14 @@ title: Supported Boards
 subtitle: RIOT has a hardware abstraction layer, which enables us to support many boards easily.
 ---
 <main>
+  <!-- ======= Deprecation warning ======= -->
+  <div class="container mt-3">
+    <div class="alert alert-warning" role="alert">
+      <strong>Deprecation notice:</strong> This page is being deprecated.
+      The updated boards information is available at
+      <a href="https://guide.riot-os.org/boards/" target="_blank">https://guide.riot-os.org/boards/</a>.
+    </div>
+  </div>
   <!-- ======= Board Section ======= -->
   <section id="boards">
     <div class="container">

--- a/cpus.html
+++ b/cpus.html
@@ -3,6 +3,14 @@ layout: simple-page
 title: Supported CPUs
 subtitle: RIOT has a hardware abstraction layer, which enables us to support many CPUs easily.
 ---
+    <!-- ======= Deprecation warning ======= -->
+    <div class="container mt-3">
+      <div class="alert alert-warning" role="alert">
+        <strong>Deprecation notice:</strong> This page is being deprecated.
+        The updated CPU information is available at
+        <a href="https://guide.riot-os.org/cpus/" target="_blank">https://guide.riot-os.org/cpus/</a>.
+      </div>
+    </div>
 
     <!-- ======= Board Section ======= -->
     <section id="cpus">


### PR DESCRIPTION
Add a small note about the pages being deprecated since I sometimes see people visiting those pages, esp. newcomers.

I could not get the tech stack for the page to work properly, presumably the ruby version arch ships was too modern? And as far as I can see there is no docker for this so this is somewhat YOLOed, hoping for the CI preview to be good enough