### PR TITLE
_tools/fetch_riot_data: escape quotes on names

### DIFF
--- a/_tools/fetch_riot_data.py
+++ b/_tools/fetch_riot_data.py
@@ -192,7 +192,7 @@ def search_data(file_paths, regexp, parent_regexp=None, multi=False):
                         continue
                     else:
                         break
-                name = match.group(2)
+                name = match.group(2).replace('"', '\\"')
                 group = match.group(1).replace("_", "__")
                 result = { "name": f"\"{name}\"", "group": group }
                 if parent_regexp is not None:


### PR DESCRIPTION
In an attempt to fix the current builds, this adds some quotes escaping to the script that extracts data from the RIOT repo. It seems a board that was recently added has `"` in its name, and yaml does not like that.